### PR TITLE
Setup /tag routes

### DIFF
--- a/__tests__/server.js
+++ b/__tests__/server.js
@@ -21,7 +21,7 @@ describe('Route integration', () => {
   });
 
   describe('/images', () => {
-    let id;
+    let photoid;
     describe('GET', () => {
       it('responds with 200 status and application/json content type', () => {
         return request(server)
@@ -62,7 +62,7 @@ describe('Route integration', () => {
             expect(response.body).toEqual(expect.objectContaining({
               photoid: expect.any(Number)
             }))
-            id = response.body.photoid;
+            photoid = response.body.photoid;
           })
 
       });
@@ -70,7 +70,7 @@ describe('Route integration', () => {
     describe("PUT", () => {
       it('responds with 200 status and application/json content type', () => {
         return request(server)
-          .put(`/images/${id}?rating=4`)
+          .put(`/images/${photoid}?rating=4`)
           .set('Accept', 'application/json')
           .expect('Content-Type', /json/)
           .expect(200)
@@ -80,7 +80,70 @@ describe('Route integration', () => {
     describe("DELETE", () => {
       it('responds with 200 status and application/json content type', () => {
         return request(server)
-          .delete(`/images/${id}`)
+          .delete(`/images/${photoid}`)
+          .set('Accept', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(200)
+      });
+    });
+  });
+  describe('/tags', () => {
+    let tagid;
+    describe('GET', () => {
+      it('responds with 200 status and application/json content type', () => {
+        return request(server)
+          .get('/tags')
+          .set('Accept', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(200);
+      });
+
+      it('returns a list of images in the body of response', () => {
+        const tagList = [{
+          "tagid": 1,
+          "tag": "Monster Trucks",
+          "userid": "1"
+        }];
+        return request(server)
+          .get('/tags')
+          .expect(200)
+          .then(response => {
+            expect([response.body[0]]).toEqual(tagList)
+          })
+      });
+    });
+    describe("POST", () => {
+      it('responds with 200 status and application/json content type with photoid in body', () => {
+        return request(server)
+          .post('/tags')
+          .send({
+            tag: "Testing"
+          })
+          .set('Accept', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(200)
+          .then(response => {
+            expect(response.body).toEqual(expect.objectContaining({
+              tagid: expect.any(Number)
+            }))
+            tagid = response.body.tagid;
+          })
+
+      });
+    });
+    describe("PUT", () => {
+      it('responds with 200 status and application/json content type', () => {
+        return request(server)
+          .put(`/images/${tagid}?photoid=1`)
+          .set('Accept', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(200)
+      });
+    });
+    describe("DELETE", () => {
+      it('responds with 200 status and application/json content type', () => {
+        return request(server)
+          .delete(`/images/${tagid}`)
           .set('Accept', 'application/json')
           .expect('Content-Type', /json/)
           .expect(200)

--- a/pg_database.sql
+++ b/pg_database.sql
@@ -1,30 +1,48 @@
+DROP TABLE IF EXISTS phototags
+CASCADE;
+DROP TABLE IF EXISTS tags
+CASCADE;
+DROP TABLE IF EXISTS photos
+CASCADE;
+DROP TABLE IF EXISTS users
+CASCADE;
+
 CREATE TABLE users
 (
   "userid" serial PRIMARY KEY,
-  "name" varchar NOT NULL CHECK ( name <> ''),
-  "profilephoto" varchar NOT NULL
+  "name" varchar NOT NULL CHECK ( name <> '')
 );
 
 SELECT setval('users_userid_seq', 1, false);
 
 CREATE TABLE photos
-  (
-    "photoid" serial PRIMARY KEY,
-    "url" varchar NOT NULL,
-    "userid" bigint NOT NULL,
-    "date" varchar NOT NULL,
-    "rating" smallint,
-    FOREIGN KEY ( userid ) REFERENCES users ( userid )
-  );
+(
+  "photoid" serial PRIMARY KEY,
+  "url" varchar NOT NULL,
+  "userid" bigint NOT NULL,
+  "date" varchar NOT NULL,
+  "rating" smallint,
+  CONSTRAINT fk_user FOREIGN KEY ( userid ) REFERENCES users ( userid ) ON DELETE CASCADE
+);
 
 SELECT setval('photos_photoid_seq', 1, false);
 
 CREATE TABLE tags
-  (
-    "tagid" serial PRIMARY KEY,
-    "tag" varchar NOT NULL CHECK ( tag <> ''),
-    "photoid" bigint NOT NULL,
-    FOREIGN KEY ( photoid ) REFERENCES photos ( photoid )
-  );
+(
+  "tagid" serial PRIMARY KEY,
+  "tag" varchar NOT NULL CHECK ( tag <> ''),
+  "userid" bigint NOT NULL,
+  CONSTRAINT fk_user FOREIGN KEY ( userid ) REFERENCES users ( userid ) ON DELETE CASCADE
+);
 
 SELECT setval('tags_tagid_seq', 1, false);
+
+CREATE TABLE phototags
+(
+  "userid" bigint NOT NULL,
+  "photoid" bigint NOT NULL,
+  "tagid" bigint NOT NULL,
+  CONSTRAINT fk_photo FOREIGN KEY ( photoid ) REFERENCES photos ( photoid ) ON DELETE CASCADE,
+  CONSTRAINT fk_user FOREIGN KEY ( userid ) REFERENCES users ( userid ) ON DELETE CASCADE,
+  CONSTRAINT fk_tag FOREIGN KEY ( tagid ) REFERENCES tags ( tagid ) ON DELETE CASCADE
+);

--- a/pg_database_test.sql
+++ b/pg_database_test.sql
@@ -1,42 +1,64 @@
+DROP TABLE IF EXISTS phototags
+CASCADE;
+DROP TABLE IF EXISTS tags
+CASCADE;
+DROP TABLE IF EXISTS photos
+CASCADE;
+DROP TABLE IF EXISTS users
+CASCADE;
+
 CREATE TABLE users
 (
-    "userid" serial PRIMARY KEY,
-    "name" varchar NOT NULL CHECK ( name <> ''),
-    "profilephoto" varchar NOT NULL
+  "userid" serial PRIMARY KEY,
+  "name" varchar NOT NULL CHECK ( name <> '')
 );
 
 SELECT setval('users_userid_seq', 1, false);
 
 CREATE TABLE photos
 (
-    "photoid" serial PRIMARY KEY,
-    "url" varchar NOT NULL,
-    "userid" bigint NOT NULL,
-    "date" varchar NOT NULL,
-    "rating" smallint,
-    FOREIGN KEY ( userid ) REFERENCES users ( userid )
+  "photoid" serial PRIMARY KEY,
+  "url" varchar NOT NULL,
+  "userid" bigint NOT NULL,
+  "date" varchar NOT NULL,
+  "rating" smallint,
+  CONSTRAINT fk_user FOREIGN KEY ( userid ) REFERENCES users ( userid ) ON DELETE CASCADE
 );
 
 SELECT setval('photos_photoid_seq', 1, false);
 
 CREATE TABLE tags
 (
-    "tagid" serial PRIMARY KEY,
-    "tag" varchar NOT NULL CHECK ( tag <> ''),
-    "photoid" bigint NOT NULL,
-    FOREIGN KEY ( photoid ) REFERENCES photos ( photoid )
+  "tagid" serial PRIMARY KEY,
+  "tag" varchar NOT NULL CHECK ( tag <> ''),
+  "userid" bigint NOT NULL,
+  CONSTRAINT fk_user FOREIGN KEY ( userid ) REFERENCES users ( userid ) ON DELETE CASCADE
 );
 
 SELECT setval('tags_tagid_seq', 1, false);
 
+CREATE TABLE phototags
+(
+  "userid" bigint NOT NULL,
+  "photoid" bigint NOT NULL,
+  "tagid" bigint NOT NULL,
+  CONSTRAINT fk_photo FOREIGN KEY ( photoid ) REFERENCES photos ( photoid ) ON DELETE CASCADE,
+  CONSTRAINT fk_user FOREIGN KEY ( userid ) REFERENCES users ( userid ) ON DELETE CASCADE,
+  CONSTRAINT fk_tag FOREIGN KEY ( tagid ) REFERENCES tags ( tagid ) ON DELETE CASCADE
+);
+
 INSERT INTO users
-    (name, profilephoto)
-VALUES('Marc', 'somephoto.jpg')
+  (name)
+VALUES('Marc');
 
 INSERT INTO photos
-    (url, userid, date, rating)
-VALUES('https://s.hdnux.com/photos/01/10/02/10/18883120/8/920x920.jpg', 1, 'today', 0)
+  (url, userid, date, rating)
+VALUES('https://s.hdnux.com/photos/01/10/02/10/18883120/8/920x920.jpg', 1, 'today', 0);
 
 INSERT INTO tags
-    (tag, photoid)
-VALUES('Monster Trucks', 1)
+  (tag, userid)
+VALUES('Monster Trucks', 1);
+
+INSERT INTO phototags
+  (userid, photoid, tagid)
+VALUES(1, 1, 1);

--- a/server/controllers/imageController.js
+++ b/server/controllers/imageController.js
@@ -3,11 +3,15 @@ const queries = require('../utils/queries');
 
 const imageController = {};
 
+//GETS ALL USERS IMAGES FROM THE DATABASE
 imageController.getImages = (req, res, next) => {
 
-  db.query(queries.getImages)
+  //hard-code userid until sessions set up
+  const userid = 1;
+
+  db.query(queries.getImages, [userid])
     .then(photos => {
-      db.query(queries.getTags)
+      db.query(queries.getAllImageTags, [userid])
         .then(tags => {
           const tagObj = {};
 
@@ -32,6 +36,7 @@ imageController.getImages = (req, res, next) => {
     })
 }
 
+//ADDS AN IMAGE TO THE DATABASE
 imageController.addImage = (req, res, next) => {
 
   //deconstruct url from body
@@ -60,8 +65,9 @@ imageController.addImage = (req, res, next) => {
         },
       });
     })
-
 }
+
+//ADDS RATING TO THE IMAGE
 imageController.updateImage = (req, res, next) => {
 
   //deconstruct url from params
@@ -80,14 +86,15 @@ imageController.updateImage = (req, res, next) => {
     })
     .catch(err => {
       return next({
-        log: `Error occurred with queries.deleteImage: ${err}`,
+        log: `Error occurred with queries.updateImage: ${err}`,
         message: {
-          err: 'An error occured with SQL when deleting an image.'
+          err: 'An error occured with SQL when updating an image.'
         },
       });
     })
 }
 
+//REMOVES USERS IMAGE
 imageController.deleteImage = (req, res, next) => {
 
   //deconstruct url from params

--- a/server/controllers/tagController.js
+++ b/server/controllers/tagController.js
@@ -1,0 +1,113 @@
+const db = require('../models/model');
+const queries = require('../utils/queries');
+
+const tagController = {};
+
+//SENDS LIST OF TAGS BACK TO CLIENT
+tagController.getTags = (req, res, next) => {
+
+  //dummy id until cookies are set up
+  const userid = 1;
+
+  db.query(queries.getTags, [userid])
+    .then(tags => {
+      res.locals.data = tags.rows;
+      return next();
+    })
+    .catch(err => {
+      return next({
+        log: `Error occurred with queries.getTags: ${err}`,
+        message: {
+          err: 'An error occured with SQL when getting tags.'
+        },
+      });
+    })
+}
+
+//ADDS A NEW TAG TO THE DATABASE
+tagController.addTag = (req, res, next) => {
+
+  //deconstruct tag name from body
+  const {
+    tag
+  } = req.body;
+
+  //dummy id until cookies are set up
+  const userid = 1;
+
+  db.query(queries.addTag, [tag, userid])
+    .then(data => {
+      res.locals.data = data.rows[0];
+      return next();
+    })
+    .catch(err => {
+      return next({
+        log: `Error occurred with queries.addTag: ${err}`,
+        message: {
+          err: 'An error occured with SQL when creating a new tag.'
+        },
+      });
+    })
+}
+
+//ADDS A TAG TO THE GIVEN PHOTOID
+tagController.updateTag = (req, res, next) => {
+
+  //dummy id until cookies are set up
+  const userid = 1;
+
+  //deconstruct tagid from params
+  const {
+    tagid
+  } = req.params;
+
+  //deconstruct photoid from query
+  const {
+    photoid
+  } = req.query;
+
+  db.query(queries.updateTag, [userid, photoid, tagid])
+    .then(data => {
+      return next();
+    })
+    .catch(err => {
+      return next({
+        log: `Error occurred with queries.updateTag: ${err}`,
+        message: {
+          err: 'An error occured with SQL when updating an image with a tag.'
+        },
+      });
+    })
+}
+
+//REMOVES A TAG FROM THE GIVEN PHOTOID
+tagController.deleteTag = (req, res, next) => {
+
+  //dummy id until cookies are set up
+  const userid = 1;
+
+  //deconstruct tagid from params
+  const {
+    tagid
+  } = req.params;
+
+  //deconstruct photoid from query
+  const {
+    photoid
+  } = req.query;
+
+  db.query(queries.deleteTag, [userid, photoid, tagid])
+    .then(data => {
+      return next();
+    })
+    .catch(err => {
+      return next({
+        log: `Error occurred with queries.deleteTag: ${err}`,
+        message: {
+          err: 'An error occured with SQL when removing a tag from an image.'
+        },
+      });
+    })
+}
+
+module.exports = tagController;

--- a/server/routes/tags.js
+++ b/server/routes/tags.js
@@ -1,2 +1,22 @@
 const express = require("express");
 const router = express.Router();
+
+const tagController = require('../controllers/tagController')
+
+router.get('/', tagController.getTags, (req, res) => {
+  return res.status(200).json(res.locals.data);
+})
+
+router.post('/', tagController.addTag, (req, res) => {
+  return res.status(200).json(res.locals.data);
+})
+
+router.put('/:tagid', tagController.updateTag, (req, res) => {
+  return res.status(200).json({});
+})
+
+router.delete('/:tagid', tagController.deleteTag, (req, res) => {
+  return res.status(200).json({});
+})
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -30,7 +30,7 @@ if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'test') {
 app.use('/images', imageRouter);
 
 // // TAGS ROUTER
-// app.use('/tags', tagRouter);
+app.use('/tags', tagRouter);
 
 // catch-all endpoint handler
 app.use((req, res) => {

--- a/server/utils/queries.js
+++ b/server/utils/queries.js
@@ -1,12 +1,10 @@
 const queries = {};
 
+//IMAGES
 queries.getImages = `
 SELECT *
-FROM photos`
-
-queries.getTags = `
-SELECT *
-FROM tags`
+FROM photos
+WHERE userid=$1`
 
 queries.addImage = `
 INSERT INTO photos(url, userid, date, rating)
@@ -16,13 +14,37 @@ RETURNING photoid`
 queries.updateImage = `
 UPDATE photos
 SET rating=$2
-WHERE photoid=$1
-`;
+WHERE photoid=$1`;
 
 queries.deleteImage = `
-DELETE FROM photos
-WHERE photoid=$1
-`;
+  DELETE FROM photos
+  WHERE photoid=$1`
 
+//TAGS
+queries.getAllImageTags = `
+SELECT t.tagid, t.tag, pt.photoid
+FROM phototags pt
+JOIN tags t
+ON t.tagid = pt.tagid
+WHERE pt.userid=$1`
+
+queries.getTags = `
+SELECT *
+  FROM tags
+WHERE userid = $1 `
+
+queries.addTag = `
+INSERT INTO tags(tag, userid)
+VALUES($1, $2)
+RETURNING tagid `
+
+queries.updateTag = `
+INSERT INTO phototags(userid, photoid, tagid)
+VALUES($1, $2, $3)
+`
+
+queries.deleteTag = `
+DELETE FROM phototags
+WHERE userid = $1 AND photoid = $2 AND tagid = $3 `
 
 module.exports = queries;


### PR DESCRIPTION
**What is the problem you were trying to solve?**
- SQL DB missing join table for photo tags
- Delete requests would not cascade to foreign tables
- Tag routes not setup

**What is your solution and why did you solve this problem the way you did?**
- Refactored the SQL database to add foreign key constraints to cascade delete commands
- Added phototags table for the many-many relationship between photos and tags
- Tag routes added:
- GET request to /tags returns all user tags
- POST request to /tags requires {tag: <value>} object in the body and will return {tagid: <value>}
- PUT request adds an entry to the phototag table and requires the following URL: /tag/:tagid?photoid=<value>
- DELETE request removes an entry to the phototag table and requires the following URL: /tag/:tagid?photoid=<value>

**Provide any additional notes on testing this functionality:**
- Preliminary tests have been setup in the testing database and tests the base use case
- Further testing should verify cascading deletes

